### PR TITLE
Fix TDO timing

### DIFF
--- a/xvcpi.c
+++ b/xvcpi.c
@@ -54,7 +54,7 @@ static int tdo_gpio = 9;
 static int verbose = 0;
 
 /* Transition delay coefficients */
-#define JTAG_DELAY (320)
+#define JTAG_DELAY (40)
 static unsigned int jtag_delay = JTAG_DELAY;
 
 static int bcm2835gpio_read(void)
@@ -80,8 +80,8 @@ static uint32_t bcm2835gpio_xfer(int n, uint32_t tms, uint32_t tdi)
 
    for (int i = 0; i < n; i++) {
       bcm2835gpio_write(0, tms & 1, tdi & 1);
-      tdo |= bcm2835gpio_read() << i;
       bcm2835gpio_write(1, tms & 1, tdi & 1);
+      tdo |= bcm2835gpio_read() << i;
       tms >>= 1;
       tdi >>= 1;
    }


### PR DESCRIPTION
Based on some research, the target asserts TDO on the falling edge of the clock, and the host samples TDO on the rising edge. Moving the read after raising TCK high should allow higher clock speeds to be used without instability.

I set the JTAG delay to 40, which I felt was a safe value, resulting in a TCK of about 4.4MHz. However, I was able to get it down to 0 without issues, giving a TCK of about 8.8MHz. With the original code, I was only ever able to get the delay down to around 100, giving a clock rate of about 2.4 MHz.